### PR TITLE
Add ShinyApp connection hooks

### DIFF
--- a/detikzify/webui/__main__.py
+++ b/detikzify/webui/__main__.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 
 from .strings import ALGORITHMS, MODELS
 from .webui import build_ui
+from .helpers import configure_hooks
 
 def parse_args():
     argument_parser = ArgumentParser(
@@ -55,6 +56,7 @@ if __name__ == "__main__":
     args = parse_args()
     share = args.pop("share")
     root_path = args.pop("root_path")
+    configure_hooks(root_path)
     build_ui(**args).queue().launch(
         share=share,
         server_port=7860,

--- a/detikzify/webui/helpers.py
+++ b/detikzify/webui/helpers.py
@@ -139,3 +139,84 @@ class GeneratorLock:
 
     def __call__(self, *args, **kwargs):
         yield from self.generate(*args, **kwargs)
+
+# ---------------------------------------------------------------------------
+# Connection helpers for integration with ShinyAppManage system
+# ---------------------------------------------------------------------------
+
+_user_info: dict = {}
+_enable_hooks: bool = False
+
+def configure_hooks(root_path: str | None):
+    """Enable connection hooks when running behind a proxy."""
+    global _enable_hooks
+    _enable_hooks = bool(root_path)
+
+def hooks_enabled() -> bool:
+    return _enable_hooks
+
+def url_execute(curl_type, cur_url, cur_data=None, cur_header=None):
+    """Utility to send HTTP requests used by the management API."""
+    if not _enable_hooks:
+        return {"code": -1}
+    import requests
+    try:
+        if curl_type == 1:
+            res = requests.get(cur_url, headers=cur_header)
+        else:
+            res = requests.post(cur_url, headers=cur_header, json=cur_data)
+        if res.status_code == 200:
+            return res.json()
+        else:
+            return {"code": -1}
+    except Exception:
+        return {"code": -1}
+
+def connect_user(request: gr.Request):
+    """Notify ShinyAppManage that a session was created."""
+    if not _enable_hooks:
+        return _user_info
+    query = dict(request.query_params or {})
+    _user_info.clear()
+    _user_info.update({
+        "id": query.get("id"),
+        "appName": query.get("appName"),
+        "token": query.get("token"),
+    })
+    token = _user_info.get("token")
+    if token:
+        headers = {"Token": token, "Content-Type": "application/json"}
+        connect_req = {
+            "appName": _user_info.get("appName"),
+            "action": "connect",
+            "id": _user_info.get("id"),
+        }
+        data = url_execute(
+            2,
+            "http://10.2.26.152/sqx_fast/app/workstation/shiny-connect-action",
+            connect_req,
+            headers,
+        )
+        if data.get("code", -1) != 0:
+            gr.Warning("Failed to notify connect action")
+    return _user_info
+
+def disconnect_user():
+    """Notify ShinyAppManage that the session ended."""
+    if not (_enable_hooks and _user_info):
+        return
+    headers = {
+        "Token": _user_info.get("token"),
+        "Content-Type": "application/json",
+    }
+    disconnect_req = {
+        "appName": _user_info.get("appName"),
+        "action": "disconnect",
+        "id": _user_info.get("id"),
+    }
+    url_execute(
+        2,
+        "http://10.2.26.152/sqx_fast/app/workstation/shiny-connect-action",
+        disconnect_req,
+        headers,
+    )

--- a/detikzify/webui/strings.py
+++ b/detikzify/webui/strings.py
@@ -129,3 +129,12 @@ GALLERY_DESELECT_HACK = """
     observer.observe(document.body, observerOptions);
 </script>
 """
+
+# Redirect to booking system home when the frontend disconnects
+REDIRECT_ON_DISCONNECT = """
+<script>
+    window.addEventListener('gradio:disconnected', function () {
+      window.location.href = 'http://10.2.26.152/';
+    });
+</script>
+"""

--- a/detikzify/webui/webui.py
+++ b/detikzify/webui/webui.py
@@ -21,8 +21,11 @@ from .helpers import (
     clear_cached_model,
     make_light,
     to_svg,
+    connect_user,
+    disconnect_user,
+    hooks_enabled,
 )
-from .strings import ALGORITHMS, BANNER, CSS, GALLERY_DESELECT_HACK, MODELS
+from .strings import ALGORITHMS, BANNER, CSS, GALLERY_DESELECT_HACK, MODELS, REDIRECT_ON_DISCONNECT
 
 def simulate(pipe, streamer, image,  preprocess, exploration, strict, timeout, thread, tmpdir):
     iterator = pipe.simulate(
@@ -138,8 +141,11 @@ def build_ui(
     algorithm=list(ALGORITHMS)[0]
 ):
     theme = make_light(gr.themes.Soft()) if light else gr.themes.Soft()
-    with gr.Blocks(css=CSS, theme=theme, title="DeTikZify", head=GALLERY_DESELECT_HACK) as demo: # type: ignore
+    head_html = GALLERY_DESELECT_HACK + (REDIRECT_ON_DISCONNECT if hooks_enabled() else "")
+    with gr.Blocks(css=CSS, theme=theme, title="DeTikZify", head=head_html) as demo: # type: ignore
         if light: make_light(demo)
+        demo.load(connect_user, None, None, queue=False)
+        demo.unload(disconnect_user)
         gr.HTML(BANNER)
         with gr.Row(variant="panel"):
             with gr.Column():


### PR DESCRIPTION
## Summary
- add helper to send HTTP requests for connect/disconnect events
- integrate connect/disconnect callbacks in the Gradio UI
- add proxy root path hooks for redirect behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e7edf76a48320923c4b09a28053b2